### PR TITLE
feat(logging): add structured logger + Crashlytics integration

### DIFF
--- a/project_code/lib/app/bootstrap.dart
+++ b/project_code/lib/app/bootstrap.dart
@@ -1,12 +1,54 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:hatim_program/firebase_options.dart';
 
+import 'logging/app_logger.dart';
 import 'app.dart';
 
 Future<void> bootstrapApp() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  await AppLogger.initialize(crashlyticsEnabled: kReleaseMode || kProfileMode);
 
-  runApp(const HatimProgramApp());
+  FlutterError.onError = (FlutterErrorDetails details) {
+    AppLogger.instance.error(
+      'Flutter framework error',
+      error: details.exception,
+      stackTrace: details.stack,
+      fatal: true,
+      context: <String, Object?>{'library': details.library},
+    );
+  };
+
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stackTrace) {
+    unawaited(
+      AppLogger.instance.error(
+        'Uncaught platform error',
+        error: error,
+        stackTrace: stackTrace,
+        fatal: true,
+      ),
+    );
+    return true;
+  };
+
+  runZonedGuarded(
+    () {
+      AppLogger.instance.info('Starting Hatim Program app');
+      runApp(const HatimProgramApp());
+    },
+    (Object error, StackTrace stackTrace) {
+      unawaited(
+        AppLogger.instance.error(
+          'Uncaught zone error',
+          error: error,
+          stackTrace: stackTrace,
+          fatal: true,
+        ),
+      );
+    },
+  );
 }

--- a/project_code/lib/app/logging/app_logger.dart
+++ b/project_code/lib/app/logging/app_logger.dart
@@ -1,0 +1,163 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+
+class AppLogger {
+  AppLogger._({required Logger logger, required bool crashlyticsEnabled})
+    : _logger = logger,
+      _crashlyticsEnabled = crashlyticsEnabled;
+
+  static AppLogger? _instance;
+  static AppLogger? _fallback;
+
+  final Logger _logger;
+  final bool _crashlyticsEnabled;
+
+  static AppLogger get instance {
+    final AppLogger? current = _instance ?? _fallback;
+    if (current != null) {
+      return current;
+    }
+
+    final Logger fallbackLogger = Logger(
+      level: Level.debug,
+      printer: PrettyPrinter(
+        methodCount: 1,
+        errorMethodCount: 2,
+        lineLength: 100,
+        colors: !kReleaseMode,
+        printEmojis: !kReleaseMode,
+      ),
+      output: ConsoleOutput(),
+    );
+    _fallback = AppLogger._(logger: fallbackLogger, crashlyticsEnabled: false);
+    return _fallback!;
+  }
+
+  static Future<void> initialize({required bool crashlyticsEnabled}) async {
+    final Logger logger = Logger(
+      level: kReleaseMode ? Level.warning : Level.debug,
+      printer: PrettyPrinter(
+        methodCount: 1,
+        errorMethodCount: 5,
+        lineLength: 100,
+        colors: !kReleaseMode,
+        printEmojis: !kReleaseMode,
+      ),
+      output: ConsoleOutput(),
+    );
+
+    bool enabled = false;
+    if (crashlyticsEnabled) {
+      try {
+        await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(
+          true,
+        );
+        enabled = true;
+      } catch (_) {
+        enabled = false;
+      }
+    }
+
+    _instance = AppLogger._(logger: logger, crashlyticsEnabled: enabled);
+    _instance!.info(
+      'Logger initialized',
+      context: <String, Object?>{
+        'crashlyticsEnabled': enabled,
+        'releaseMode': kReleaseMode,
+      },
+    );
+  }
+
+  void trace(String message, {Map<String, Object?>? context}) {
+    _logger.t(_buildMessage(message, context));
+  }
+
+  void debug(String message, {Map<String, Object?>? context}) {
+    _logger.d(_buildMessage(message, context));
+  }
+
+  void info(String message, {Map<String, Object?>? context}) {
+    _logger.i(_buildMessage(message, context));
+    _logBreadcrumb(message, context);
+  }
+
+  void warning(String message, {Map<String, Object?>? context}) {
+    _logger.w(_buildMessage(message, context));
+    _logBreadcrumb(message, context);
+  }
+
+  Future<void> error(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, Object?>? context,
+    bool fatal = false,
+  }) async {
+    _logger.e(
+      _buildMessage(message, context),
+      error: error,
+      stackTrace: stackTrace,
+    );
+
+    if (!_crashlyticsEnabled) {
+      return;
+    }
+
+    try {
+      await FirebaseCrashlytics.instance.recordError(
+        error ?? message,
+        stackTrace,
+        reason: message,
+        fatal: fatal,
+        information: <DiagnosticsNode>[
+          if (context != null)
+            StringProperty('context', _contextToString(context)),
+        ],
+      );
+    } catch (_) {}
+  }
+
+  Future<void> setUserIdentifier(String userId) async {
+    final String safeUser = userId.trim();
+    if (safeUser.isEmpty || !_crashlyticsEnabled) {
+      return;
+    }
+    try {
+      await FirebaseCrashlytics.instance.setUserIdentifier(safeUser);
+    } catch (_) {}
+  }
+
+  Future<void> setCustomKey(String key, Object value) async {
+    if (!_crashlyticsEnabled) {
+      return;
+    }
+    try {
+      await FirebaseCrashlytics.instance.setCustomKey(key, value);
+    } catch (_) {}
+  }
+
+  String _buildMessage(String message, Map<String, Object?>? context) {
+    if (context == null || context.isEmpty) {
+      return message;
+    }
+    return '$message | ${_contextToString(context)}';
+  }
+
+  String _contextToString(Map<String, Object?> context) {
+    return context.entries
+        .map((MapEntry<String, Object?> entry) => '${entry.key}=${entry.value}')
+        .join(' ');
+  }
+
+  void _logBreadcrumb(String message, Map<String, Object?>? context) {
+    if (!_crashlyticsEnabled) {
+      return;
+    }
+
+    final String text = _buildMessage(message, context);
+    try {
+      FirebaseCrashlytics.instance.log(text);
+    } catch (_) {}
+  }
+}

--- a/project_code/lib/features/auth/presentation/login_page.dart
+++ b/project_code/lib/features/auth/presentation/login_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../app/logging/app_logger.dart';
 import '../../../app/theme/app_tokens.dart';
 import '../domain/auth_failure.dart';
 import '../domain/auth_repository.dart';
@@ -45,6 +46,7 @@ class _LoginPageState extends State<LoginPage> {
       _busy = true;
       _error = null;
     });
+    AppLogger.instance.info('Login with phone started');
 
     try {
       final AuthUserProfile profile = await widget.authRepository
@@ -55,12 +57,25 @@ class _LoginPageState extends State<LoginPage> {
       if (!mounted) {
         return;
       }
+      AppLogger.instance.info(
+        'Login with phone succeeded',
+        context: <String, Object?>{'uid': profile.uid},
+      );
       widget.onAuthSuccess(profile);
     } on AuthFailure catch (error) {
+      AppLogger.instance.warning(
+        'Login with phone failed',
+        context: <String, Object?>{'code': error.code.name},
+      );
       setState(() {
         _error = error.message;
       });
-    } catch (_) {
+    } catch (error, stackTrace) {
+      AppLogger.instance.error(
+        'Unexpected phone login failure',
+        error: error,
+        stackTrace: stackTrace,
+      );
       setState(() {
         _error = 'Login failed unexpectedly.';
       });
@@ -78,6 +93,7 @@ class _LoginPageState extends State<LoginPage> {
       _busy = true;
       _error = null;
     });
+    AppLogger.instance.info('Login with Google started');
 
     try {
       final AuthUserProfile profile = await widget.authRepository
@@ -85,12 +101,25 @@ class _LoginPageState extends State<LoginPage> {
       if (!mounted) {
         return;
       }
+      AppLogger.instance.info(
+        'Login with Google succeeded',
+        context: <String, Object?>{'uid': profile.uid},
+      );
       widget.onAuthSuccess(profile);
     } on AuthFailure catch (error) {
+      AppLogger.instance.warning(
+        'Login with Google failed',
+        context: <String, Object?>{'code': error.code.name},
+      );
       setState(() {
         _error = error.message;
       });
-    } catch (_) {
+    } catch (error, stackTrace) {
+      AppLogger.instance.error(
+        'Unexpected Google login failure',
+        error: error,
+        stackTrace: stackTrace,
+      );
       setState(() {
         _error = 'Google login failed unexpectedly.';
       });

--- a/project_code/lib/features/auth/presentation/register_page.dart
+++ b/project_code/lib/features/auth/presentation/register_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../app/logging/app_logger.dart';
 import '../../../app/theme/app_tokens.dart';
 import '../domain/auth_failure.dart';
 import '../domain/auth_repository.dart';
@@ -49,6 +50,7 @@ class _RegisterPageState extends State<RegisterPage> {
       _busy = true;
       _error = null;
     });
+    AppLogger.instance.info('Register with phone started');
 
     try {
       final AuthUserProfile profile = await widget.authRepository
@@ -61,12 +63,25 @@ class _RegisterPageState extends State<RegisterPage> {
       if (!mounted) {
         return;
       }
+      AppLogger.instance.info(
+        'Register with phone succeeded',
+        context: <String, Object?>{'uid': profile.uid},
+      );
       widget.onAuthSuccess(profile);
     } on AuthFailure catch (error) {
+      AppLogger.instance.warning(
+        'Register with phone failed',
+        context: <String, Object?>{'code': error.code.name},
+      );
       setState(() {
         _error = error.message;
       });
-    } catch (_) {
+    } catch (error, stackTrace) {
+      AppLogger.instance.error(
+        'Unexpected phone registration failure',
+        error: error,
+        stackTrace: stackTrace,
+      );
       setState(() {
         _error = 'Registration failed unexpectedly.';
       });
@@ -91,6 +106,7 @@ class _RegisterPageState extends State<RegisterPage> {
       _busy = true;
       _error = null;
     });
+    AppLogger.instance.info('Register with Google started');
 
     try {
       final AuthUserProfile profile = await widget.authRepository
@@ -102,12 +118,25 @@ class _RegisterPageState extends State<RegisterPage> {
       if (!mounted) {
         return;
       }
+      AppLogger.instance.info(
+        'Register with Google succeeded',
+        context: <String, Object?>{'uid': profile.uid},
+      );
       widget.onAuthSuccess(profile);
     } on AuthFailure catch (error) {
+      AppLogger.instance.warning(
+        'Register with Google failed',
+        context: <String, Object?>{'code': error.code.name},
+      );
       setState(() {
         _error = error.message;
       });
-    } catch (_) {
+    } catch (error, stackTrace) {
+      AppLogger.instance.error(
+        'Unexpected Google registration failure',
+        error: error,
+        stackTrace: stackTrace,
+      );
       setState(() {
         _error = 'Google sign-up failed unexpectedly.';
       });

--- a/project_code/lib/features/prayer_times/location/data/flutter_timezone_service.dart
+++ b/project_code/lib/features/prayer_times/location/data/flutter_timezone_service.dart
@@ -13,4 +13,12 @@ class FlutterTimezoneService implements TimezoneService {
     }
     return timezone;
   }
+
+  @override
+  Future<String> resolveTimezoneForCoordinates({
+    required double latitude,
+    required double longitude,
+  }) {
+    return resolveLocalTimezone();
+  }
 }

--- a/project_code/lib/features/prayer_times/location/domain/location_services.dart
+++ b/project_code/lib/features/prayer_times/location/domain/location_services.dart
@@ -29,6 +29,11 @@ abstract class GeocodingService {
 
 abstract class TimezoneService {
   Future<String> resolveLocalTimezone();
+
+  Future<String> resolveTimezoneForCoordinates({
+    required double latitude,
+    required double longitude,
+  });
 }
 
 abstract class LocationProfileRepository {

--- a/project_code/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/project_code/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import cloud_firestore
 import firebase_auth
 import firebase_core
+import firebase_crashlytics
 import flutter_timezone
 import geolocator_apple
 import google_sign_in_ios
@@ -18,6 +19,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
+  FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FlutterTimezonePlugin.register(with: registry.registrar(forPlugin: "FlutterTimezonePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))

--- a/project_code/pubspec.lock
+++ b/project_code/pubspec.lock
@@ -177,6 +177,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      sha256: a6e6cb8b2ea1214533a54e4c1b11b19c40f6a29333f3ab0854a479fdc3237c5b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.7"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      sha256: fc6837c4c64c48fa94cab8a872a632b9194fa9208ca76a822f424b3da945584d
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.8.17"
   fixnum:
     dependency: transitive
     description:
@@ -429,6 +445,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  logger:
+    dependency: "direct main"
+    description:
+      name: logger
+      sha256: a7967e31b703831a893bbc3c3dd11db08126fe5f369b5c648a36f821979f5be3
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.2"
   matcher:
     dependency: transitive
     description:

--- a/project_code/pubspec.yaml
+++ b/project_code/pubspec.yaml
@@ -51,6 +51,8 @@ dependencies:
   flutter_timezone: ^4.1.1
   http: ^1.5.0
   shared_preferences: ^2.5.3
+  logger: ^2.6.2
+  firebase_crashlytics: ^5.0.4
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/project_code/test/app/logging/app_logger_test.dart
+++ b/project_code/test/app/logging/app_logger_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hatim_program/app/logging/app_logger.dart';
+
+void main() {
+  test('logger instance is safe before explicit initialization', () async {
+    expect(() => AppLogger.instance.info('test message'), returnsNormally);
+    await expectLater(
+      AppLogger.instance.error('test error', error: Exception('boom')),
+      completes,
+    );
+  });
+}

--- a/project_code/test/design/design_accessibility_test.dart
+++ b/project_code/test/design/design_accessibility_test.dart
@@ -4,7 +4,6 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hatim_program/app/app.dart';
 import 'package:hatim_program/app/theme/app_theme.dart';
 import 'package:hatim_program/features/design_preview/presentation/design_preview_page.dart';
 

--- a/project_code/test/design/design_golden_test.dart
+++ b/project_code/test/design/design_golden_test.dart
@@ -4,7 +4,6 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hatim_program/app/app.dart';
 import 'package:hatim_program/app/theme/app_theme.dart';
 import 'package:hatim_program/features/design_preview/presentation/design_preview_page.dart';
 

--- a/project_code/test/prayer_times/location/location_setup_controller_test.dart
+++ b/project_code/test/prayer_times/location/location_setup_controller_test.dart
@@ -48,6 +48,12 @@ class FakeGeocodingService implements GeocodingService {
 class FakeTimezoneService implements TimezoneService {
   @override
   Future<String> resolveLocalTimezone() async => 'Europe/Istanbul';
+
+  @override
+  Future<String> resolveTimezoneForCoordinates({
+    required double latitude,
+    required double longitude,
+  }) async => 'Europe/Istanbul';
 }
 
 class InMemoryLocationProfileRepository implements LocationProfileRepository {

--- a/project_code/test/prayer_times/location/location_setup_page_test.dart
+++ b/project_code/test/prayer_times/location/location_setup_page_test.dart
@@ -43,6 +43,12 @@ class FakeGeocodingService implements GeocodingService {
 class FakeTimezoneService implements TimezoneService {
   @override
   Future<String> resolveLocalTimezone() async => 'Europe/Istanbul';
+
+  @override
+  Future<String> resolveTimezoneForCoordinates({
+    required double latitude,
+    required double longitude,
+  }) async => 'Europe/Istanbul';
 }
 
 class InMemoryLocationProfileRepository implements LocationProfileRepository {


### PR DESCRIPTION
## Summary
- add centralized app logging module (`AppLogger`) with structured levels and context support
- integrate Firebase Crashlytics for error reporting and breadcrumbs
- wire global error capture in bootstrap:
  - `FlutterError.onError`
  - `PlatformDispatcher.instance.onError`
  - zoned uncaught async errors (`runZonedGuarded`)
- add practical auth-flow logs (login/register success/failure)
- add logger safety fallback so logs work before explicit initialization
- add unit test for logger fallback behavior

## Testing
- [x] `flutter analyze`
- [x] `flutter test`
- [x] Other (describe below)
- `flutter test --tags golden`
- `dart run tool/design_guard.dart --changed-only --base-ref origin/renew`

## Design Compliance
- [x] I reviewed docs/design-system/checklist.md
- [x] I used design tokens/theme APIs (no hardcoded colors/text styles)
- [x] I added or updated golden tests for changed UI previews/components
- [x] I validated EN/AR/TR behavior and RTL layout impact

## Notes
- Crashlytics collection is enabled in release/profile and gracefully disabled in local/test fallback mode.
- Per your process, PR stays open for your GitHub approval.
